### PR TITLE
add deprecation notice

### DIFF
--- a/bitcore/README.md
+++ b/bitcore/README.md
@@ -3,9 +3,9 @@ Bitcore
 
 A pure and powerful JavaScript Bitcoin library.
 
-## Principles
+### DEPRECATION NOTICE
 
-Bitcoin is a powerful new peer-to-peer platform for the next generation of financial technology. The decentralized nature of the Bitcoin network allows for highly resilient bitcoin infrastructure, and the developer community needs reliable, open-source tools to implement bitcoin apps and services.
+This Meteor package is no longer being maintained. Use [frabrunelle:bitcore-lib](https://atmospherejs.com/frabrunelle/bitcore-lib) instead. It works on both the client and the server.
 
 ## Get Started
 


### PR DESCRIPTION
So I was waiting to see what BitPay would do. Now the rename is very clear and they've updated the [bitcore website](https://bitcore.io/).

> Bitcore is a full bitcoin node — your apps run directly on the peer-to-peer network. By binding directly into bitcoind's source code, Bitcore's API is 20x faster than connecting to a separate bitcoin node, and orders of magnitude faster than a centralized API.
> 
> Bitcore is 100% open source, powered by the time-tested and battle-hardened Bitcore Library.

And if you go on the [bitcore repo](https://github.com/bitpay/bitcore/), it says:

> Note: If you're looking for the Bitcore Library please see: https://github.com/bitpay/bitcore-lib

Given the fact that it's not possible to rename a package in Meteor, I think it makes sense for me to create my own `bitcore-lib` package. That way it will be consistent with the packages on other platforms (e.g. `npm install bitcore-lib` and `bower install bitcore-lib`).

So I just created the `frabrunelle:bitcore-lib` package: https://github.com/frabrunelle/meteor-bitcore-lib

I also added a deprecation notice to your package on Atmosphere: https://atmospherejs.com/mikamai/bitcore, suggesting to use my package instead.

I'll wait for my package to get a few downloads and then I will hide your package from the Atmosphere search results by running the following command: `meteor admin set-unmigrated mikamai:bitcore`.

Feel free to merge this pull request to add the deprecation notice to your GitHub repository as well.

And let me know if you have any questions or concerns :smiley: 

Cheers!
